### PR TITLE
fix(ci): Decouple container-publish and cargo-binaries from crates.io outdated check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ permissions:
   pull-requests: write
 
 jobs:
+  project:
+    # https://github.com/42ByteLabs/.github/blob/main/.github/workflows/project.yml
+    uses: 42ByteLabs/.github/.github/workflows/project.yml@main
+    secrets: inherit
+
   cargo-publish:
     # https://github.com/42ByteLabs/.github/blob/main/.github/workflows/cargo-publish.yml
     uses: 42ByteLabs/.github/.github/workflows/cargo-publish.yml@main
@@ -20,22 +25,22 @@ jobs:
   cargo-binaries:
     # https://github.com/42ByteLabs/.github/blob/main/.github/workflows/cargo-binaries.yml
     uses: 42ByteLabs/.github/.github/workflows/cargo-binaries.yml@main
-    if: ${{ needs.cargo-publish.outputs.crate-outdated == 'true' }}
-    needs: [cargo-publish]
+    if: ${{ needs.project.outputs.release == 'true' }}
+    needs: [project, cargo-publish]
     secrets: inherit
     permissions:
       contents: write
       id-token: write
       attestations: write
     with:
-      version: ${{ needs.cargo-publish.outputs.version }}
+      version: ${{ needs.project.outputs.version }}
       crate: patch-release-me
 
   container-publish:
     # https://github.com/42ByteLabs/.github/blob/main/.github/workflows/container.yml
     uses: 42ByteLabs/.github/.github/workflows/container.yml@main
-    if: ${{ needs.cargo-publish.outputs.crate-outdated == 'true' }}
-    needs: [cargo-publish]
+    if: ${{ needs.project.outputs.release == 'true' }}
+    needs: [project]
     secrets: inherit
     permissions:
       id-token: write
@@ -44,5 +49,5 @@ jobs:
       attestations: write
       security-events: write
     with:
-      version: ${{ needs.cargo-publish.outputs.version }}
+      version: ${{ needs.project.outputs.version }}
       container-name: "42bytelabs/patch-release-me"


### PR DESCRIPTION
## Summary

Fixes #159. Release `0.6.6` did not publish a container image to `ghcr.io` because `container-publish` and `cargo-binaries` are gated on `needs.cargo-publish.outputs.crate-outdated == ''true''`, which reflects whether **crates.io** considers the crate outdated - not whether a new GitHub release/tag actually happened.

## Root cause

Commit 590fe1f ("feat(ci): Update release and remove train + security workflows") removed the `project` job and switched the gating condition for `cargo-binaries` and `container-publish` from `needs.project.outputs.release` to `needs.cargo-publish.outputs.crate-outdated`. These are independent signals: a crate can already be up to date on crates.io while a new GitHub release/container image is still needed for the same version bump (or vice versa). In the `0.6.6` run, `crate-outdated` evaluated to something other than `true`, so both jobs were silently skipped even though a real release was cut.

## Fix

Restore the `project` job (https://github.com/42ByteLabs/.github/blob/main/.github/workflows/project.yml), which determines whether a new release is needed by comparing the version in `.release.yml`/`Cargo.toml` against the latest published GitHub release tag. Gate `cargo-binaries` and `container-publish` on `needs.project.outputs.release == ''true''` again, decoupling them from the crates.io "outdated" check. `cargo-publish` itself is left ungated (as it was before), since publishing to crates.io is idempotent/safe to attempt on every push to `main`.

## Testing

- Validated the updated `.github/workflows/release.yml` parses as valid YAML.
- No functional runtime changes beyond the workflow gating conditions; reusable workflow calls (`project.yml`, `cargo-publish.yml`, `cargo-binaries.yml`, `container.yml`) are unchanged and were used by this repo prior to 590fe1f.