### PR TITLE
fix(action): split -m flag and value into separate args list items

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,4 +20,5 @@ runs:
   image: "actions/Dockerfile"
   args:
     - bump
-    - -m "${{ inputs.mode }}"
+    - -m
+    - ${{ inputs.mode }}


### PR DESCRIPTION
## Bug

The Docker container action always bumped the patch version regardless of the `mode` input (`minor`/`major` were silently ignored). See #161.

## Root cause

In `action.yml`, the `args` list combined the flag and its value into a single string:

```yaml
args:
  - bump
  - -m "${{ inputs.mode }}"
```

Docker `args` entries each become one argv token passed to the container's entrypoint. That means the container received a single literal token `-m "minor"` (quotes included) instead of two separate tokens `-m` and `minor`. `clap` (used in `src/cli.rs`, `#[clap(short, long, env)] mode: Option<String>`) cannot parse a flag and its value out of one combined token, so `mode` was never populated and the CLI fell back to its default patch bump.

## Fix

Split `-m` and the value into separate list items so each is passed as its own argv entry:

```yaml
args:
  - bump
  - -m
  - ${{ inputs.mode }}
```

## Verification

- Confirmed via `src/cli.rs` that `mode` is parsed via `clap` short flag `-m`, which expects the value as a separate argv token.
- No other consumers of this `args:` block exist in the repo.

Fixes #161